### PR TITLE
Bugfix

### DIFF
--- a/src/rfm69_rp2040_interface.c
+++ b/src/rfm69_rp2040_interface.c
@@ -423,6 +423,7 @@ bool rfm69_power_level_set(rfm69_context_t *rfm, int8_t pa_level) {
 	bool success = false;
 
     if (rfm->pa_level == pa_level) {
+        success = true;
         rfm->return_status = RFM69_OK;
 		goto RETURN;
 	}


### PR DESCRIPTION
The rfm69_power_level_set returns false if the power level is already configured to the level requested.

To me that makes checking the return codes ambiguous as the intended effect was correct ie the power was configured but the return code is false.

Setting the return before the goto statement solves it.